### PR TITLE
Add single message consumer

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	StatsHandler StatsHandler
 
 	MultiMessagesConsumer MultiMessagesConsumer
+
+	SingleMessageConsumer SingleMessageConsumer
 }
 
 func (c *Config) apply(opts []Option) {

--- a/context_helper.go
+++ b/context_helper.go
@@ -14,3 +14,12 @@ func GetLogger(ctx context.Context) Logger {
 func setLogger(ctx context.Context, l Logger) context.Context {
 	return context.WithValue(ctx, loggerContextKey{}, l)
 }
+
+func queuingContext(sh StatsHandler) func() context.Context {
+	return func() context.Context {
+		ctx := context.Background()
+		ctx = sh.TagProcess(ctx, &BeginTag{})
+		ctx = sh.TagProcess(ctx, &EnqueueTag{})
+		return ctx
+	}
+}

--- a/engine.go
+++ b/engine.go
@@ -52,12 +52,12 @@ func (e *Engine) Start(ctx context.Context) error {
 	)
 
 	if e.SingleMessageConsumer != nil {
-		inCh, outCh = createQueue(e.createStatsHandlerCtx)
+		inCh, outCh = createQueue(e.createStatsTagCtx)
 	}
 
 	if e.MultiMessagesConsumer != nil {
 		inCh, outCh = createBufferedQueue(
-			e.createStatsHandlerCtx,
+			e.createStatsTagCtx,
 			e.ChunkSize,
 			e.FlushInterval,
 		)
@@ -79,7 +79,7 @@ func (e *Engine) Start(ctx context.Context) error {
 	return errors.WithStack(err)
 }
 
-func (e *Engine) createStatsHandlerCtx() context.Context {
+func (e *Engine) createStatsTagCtx() context.Context {
 	ctx := context.Background()
 	ctx = e.StatsHandler.TagProcess(ctx, &BeginTag{})
 	ctx = e.StatsHandler.TagProcess(ctx, &EnqueueTag{})

--- a/engine.go
+++ b/engine.go
@@ -62,12 +62,14 @@ func (e *Engine) Start(ctx context.Context) error {
 	)
 
 	if e.SingleMessageConsumer != nil {
-		inCh, outCh = createQueue(e.createStatsTagCtx)
+		inCh, outCh = createQueue(
+			queuingContext(e.StatsHandler),
+		)
 	}
 
 	if e.MultiMessagesConsumer != nil {
 		inCh, outCh = createBufferedQueue(
-			e.createStatsTagCtx,
+			queuingContext(e.StatsHandler),
 			e.ChunkSize,
 			e.FlushInterval,
 		)
@@ -87,13 +89,6 @@ func (e *Engine) Start(ctx context.Context) error {
 	err := eg.Wait()
 
 	return errors.WithStack(err)
-}
-
-func (e *Engine) createStatsTagCtx() context.Context {
-	ctx := context.Background()
-	ctx = e.StatsHandler.TagProcess(ctx, &BeginTag{})
-	ctx = e.StatsHandler.TagProcess(ctx, &EnqueueTag{})
-	return ctx
 }
 
 func (e *Engine) watchShutdownSignal(sigstopCh <-chan struct{}, cancel context.CancelFunc) error {

--- a/engine.go
+++ b/engine.go
@@ -119,14 +119,12 @@ func (e *Engine) watchShutdownSignal(sigstopCh <-chan struct{}, cancel context.C
 }
 
 func (e *Engine) consume(qm queuedMessage) error {
-	switch m := qm.(type) {
-	case *singleMessage:
+	if m, ok := qm.(*singleMessage); ok {
 		return errors.WithStack(e.SingleMessageConsumer.Consume(m.Ctx, m.Msg))
-	case *multiMessages:
-		return errors.WithStack(e.MultiMessagesConsumer.Consume(m.Ctx, m.Msgs))
 	}
 
-	return errors.New("unsupported message type")
+	m := qm.(*multiMessages)
+	return errors.WithStack(e.MultiMessagesConsumer.Consume(m.Ctx, m.Msgs))
 }
 
 func (e *Engine) handle(msgCh <-chan queuedMessage) error {

--- a/engine.go
+++ b/engine.go
@@ -111,7 +111,7 @@ func (e *Engine) watchShutdownSignal(sigstopCh <-chan struct{}, cancel context.C
 func (e *Engine) consume(qm queuedMessage) error {
 	switch m := qm.(type) {
 	case *singleMessage:
-		// TODO (@hlts2): consume single message.
+		return e.SingleMessageConsumer.Consume(m.Ctx, m.Msg)
 	case *multiMessages:
 		return e.MultiMessagesConsumer.Consume(m.Ctx, m.Msgs)
 	}

--- a/engine.go
+++ b/engine.go
@@ -121,13 +121,12 @@ func (e *Engine) watchShutdownSignal(sigstopCh <-chan struct{}, cancel context.C
 func (e *Engine) consume(qm queuedMessage) error {
 	switch m := qm.(type) {
 	case *singleMessage:
-		return e.SingleMessageConsumer.Consume(m.Ctx, m.Msg)
+		return errors.WithStack(e.SingleMessageConsumer.Consume(m.Ctx, m.Msg))
 	case *multiMessages:
-		return e.MultiMessagesConsumer.Consume(m.Ctx, m.Msgs)
+		return errors.WithStack(e.MultiMessagesConsumer.Consume(m.Ctx, m.Msgs))
 	}
 
-	// TODO(@hlts2): return error.
-	return nil
+	return errors.New("unsupported message type")
 }
 
 func (e *Engine) handle(msgCh <-chan queuedMessage) error {

--- a/engine.go
+++ b/engine.go
@@ -22,6 +22,16 @@ func New(subscriber Subscriber, consumer MultiMessagesConsumer, opts ...Option) 
 	return newEngine(subscriber, consumer, nil, opts...)
 }
 
+// NewWithSingleMessageConsumer creates a Engine intstance with SingleMessageConsumer.
+func NewWithSingleMessageConsumer(subscriber Subscriber, consumer SingleMessageConsumer, opts ...Option) *Engine {
+	return newEngine(subscriber, nil, consumer, opts...)
+}
+
+// NewWithMultiMessagesConsumer creates a Engine intstance with MultiMessagesConsumer.
+func NewWithMultiMessagesConsumer(subscriber Subscriber, consumer MultiMessagesConsumer, opts ...Option) *Engine {
+	return newEngine(subscriber, consumer, nil, opts...)
+}
+
 func newEngine(subscriber Subscriber, mConsumer MultiMessagesConsumer, sConsumer SingleMessageConsumer, opts ...Option) *Engine {
 	cfg := newDefaultConfig()
 	cfg.MultiMessagesConsumer = mConsumer

--- a/engine.go
+++ b/engine.go
@@ -19,8 +19,13 @@ type Engine struct {
 
 // New creates a Engine intstance.
 func New(subscriber Subscriber, consumer MultiMessagesConsumer, opts ...Option) *Engine {
+	return newEngine(subscriber, consumer, nil, opts...)
+}
+
+func newEngine(subscriber Subscriber, mConsumer MultiMessagesConsumer, sConsumer SingleMessageConsumer, opts ...Option) *Engine {
 	cfg := newDefaultConfig()
-	cfg.MultiMessagesConsumer = consumer
+	cfg.MultiMessagesConsumer = mConsumer
+	cfg.SingleMessageConsumer = sConsumer
 	cfg.apply(opts)
 
 	e := &Engine{

--- a/engine.go
+++ b/engine.go
@@ -17,11 +17,6 @@ type Engine struct {
 	subscriber Subscriber
 }
 
-// New creates a Engine intstance.
-func New(subscriber Subscriber, consumer MultiMessagesConsumer, opts ...Option) *Engine {
-	return newEngine(subscriber, consumer, nil, opts...)
-}
-
 // NewWithSingleMessageConsumer creates a Engine intstance with SingleMessageConsumer.
 func NewWithSingleMessageConsumer(subscriber Subscriber, consumer SingleMessageConsumer, opts ...Option) *Engine {
 	return newEngine(subscriber, nil, consumer, opts...)

--- a/engine_test.go
+++ b/engine_test.go
@@ -182,7 +182,7 @@ func TestEngineWithMultiMessagesConsumer(t *testing.T) {
 		return nil
 	})
 
-	engine := subee.New(
+	engine := subee.NewWithMultiMessagesConsumer(
 		subscriber,
 		consumer,
 		subee.WithChunkSize(3),

--- a/engine_test.go
+++ b/engine_test.go
@@ -106,7 +106,7 @@ func TestEngineWithSingleMessageConsumer(t *testing.T) {
 	}
 }
 
-func TestEngine(t *testing.T) {
+func TestEngineWithMultiMessagesConsumer(t *testing.T) {
 	in := [][][]byte{
 		{
 			[]byte("foo"),

--- a/engine_test.go
+++ b/engine_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestEngineWithSingleMessageConsumer(t *testing.T) {
 	in := [][]byte{
+		[]byte("foo"),
 		[]byte("error!!"),
 	}
 
@@ -30,6 +31,10 @@ func TestEngineWithSingleMessageConsumer(t *testing.T) {
 	}
 
 	cases := []TestCase{
+		{
+			test: "acked when no error",
+			want: subee_testing.NewFakeMessage([]byte("foo"), true, false),
+		},
 		{
 			test: "nacked when errored",
 			want: subee_testing.NewFakeMessage([]byte("error!!"), false, true),

--- a/interceptor.go
+++ b/interceptor.go
@@ -21,3 +21,19 @@ func (f MultiMessagesConsumerFunc) Consume(ctx context.Context, msgs []Message) 
 
 // MultiMessagesConsumerInterceptor provides a hook to intercept the execution of a multiple message consumption.
 type MultiMessagesConsumerInterceptor func(MultiMessagesConsumer) MultiMessagesConsumer
+
+// SingleMessageConsumer represents an interface that consume single message.
+type SingleMessageConsumer interface {
+	Consume(context.Context, Message) error
+}
+
+// SingleMessageConsumerFunc type is an adapter to allow the use of ordinary functions as SingleMessageConsumer.
+type SingleMessageConsumerFunc func(context.Context, Message) error
+
+// Consume call f(ctx, msgs)
+func (f SingleMessageConsumerFunc) Consume(ctx context.Context, msg Message) error {
+	return errors.WithStack(f(ctx, msg))
+}
+
+// SingleMessageConsumerInterceptor provides a hook to intercept the execution of a multiple message consumption.
+type SingleMessageConsumerInterceptor func(SingleMessageConsumer) SingleMessageConsumer

--- a/message.go
+++ b/message.go
@@ -2,7 +2,12 @@ package subee
 
 // Message is an interface of the subscribed message.
 type Message interface {
+	Acknowledger
+	Data() []byte
+}
+
+// Acknowledger is an interface to send ack or nack.
+type Acknowledger interface {
 	Ack()
 	Nack()
-	Data() []byte
 }

--- a/message.go
+++ b/message.go
@@ -6,7 +6,7 @@ type Message interface {
 	Data() []byte
 }
 
-// Acknowledger is an interface to send ack or nack.
+// Acknowledger is an interface to send ACK/NACK.
 type Acknowledger interface {
 	Ack()
 	Nack()

--- a/middlewares/logging/zap/zap_interceptor.go
+++ b/middlewares/logging/zap/zap_interceptor.go
@@ -11,7 +11,26 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// MultiMessagesConsumerInterceptor returns a new interceptor for logging with zap.
+// SingleMessageConsumerInterceptor returns a new single message consumer interceptor for logging with zap.
+func SingleMessageConsumerInterceptor(logger *zap.Logger) subee.SingleMessageConsumerInterceptor {
+	return func(consumer subee.SingleMessageConsumer) subee.SingleMessageConsumer {
+		return subee.SingleMessageConsumerFunc(func(ctx context.Context, msg subee.Message) error {
+			msgCnt := 1
+
+			startConsume(logger, msgCnt)
+
+			startTime := time.Now()
+
+			err := consumer.Consume(ctx, msg)
+
+			endConsume(logger, time.Since(startTime), msgCnt, err)
+
+			return errors.WithStack(err)
+		})
+	}
+}
+
+// MultiMessagesConsumerInterceptor returns a new multi messages consumer interceptor for logging with zap.
 func MultiMessagesConsumerInterceptor(logger *zap.Logger) subee.MultiMessagesConsumerInterceptor {
 	return func(consumer subee.MultiMessagesConsumer) subee.MultiMessagesConsumer {
 		return subee.MultiMessagesConsumerFunc(func(ctx context.Context, msgs []subee.Message) error {

--- a/middlewares/logging/zap/zap_interceptor.go
+++ b/middlewares/logging/zap/zap_interceptor.go
@@ -11,6 +11,10 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+var since = func(t time.Time) time.Duration {
+	return time.Since(t)
+}
+
 // SingleMessageConsumerInterceptor returns a new single message consumer interceptor for logging with zap.
 func SingleMessageConsumerInterceptor(logger *zap.Logger) subee.SingleMessageConsumerInterceptor {
 	return func(consumer subee.SingleMessageConsumer) subee.SingleMessageConsumer {
@@ -23,7 +27,7 @@ func SingleMessageConsumerInterceptor(logger *zap.Logger) subee.SingleMessageCon
 
 			err := consumer.Consume(ctx, msg)
 
-			endConsume(logger, time.Since(startTime), msgCnt, err)
+			endConsume(logger, since(startTime), msgCnt, err)
 
 			return errors.WithStack(err)
 		})
@@ -40,7 +44,7 @@ func MultiMessagesConsumerInterceptor(logger *zap.Logger) subee.MultiMessagesCon
 
 			err := consumer.Consume(ctx, msgs)
 
-			endConsume(logger, time.Since(startTime), len(msgs), err)
+			endConsume(logger, since(startTime), len(msgs), err)
 
 			return errors.WithStack(err)
 		})

--- a/middlewares/logging/zap/zap_interceptor_test.go
+++ b/middlewares/logging/zap/zap_interceptor_test.go
@@ -42,6 +42,11 @@ func TestSingleMessageConsumerInterceptor(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := dummyLogger(buf)
 
+	want := `{"level":"INFO","msg":"Start consume message.","message_count":1}
+{"level":"INFO","msg":"called single message consumer func"}
+{"level":"INFO","msg":"End consume message.","message_count":1,"time":"0s"}
+`
+
 	SingleMessageConsumerInterceptor(logger)(
 		subee.SingleMessageConsumerFunc(func(ctx context.Context, msg subee.Message) error {
 			logger.Info("called single message consumer func")
@@ -52,11 +57,7 @@ func TestSingleMessageConsumerInterceptor(t *testing.T) {
 		message_testing.NewFakeMessage(nil, false, false),
 	)
 
-	want := `{"level":"INFO","msg":"Start consume message.","message_count":1}
-{"level":"INFO","msg":"called single message consumer func"}
-{"level":"INFO","msg":"End consume message.","message_count":1,"time":"0s"}
-`
-	if got, want := buf.String(), want; got != want {
+	if got := buf.String(); got != want {
 		t.Errorf("\nwant:\n%sgot:\n%s", want, got)
 	}
 }
@@ -73,6 +74,11 @@ func TestMultiMessagesConsumerInterceptor(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := dummyLogger(buf)
 
+	want := `{"level":"INFO","msg":"Start consume message.","message_count":2}
+{"level":"INFO","msg":"called single message consumer func"}
+{"level":"INFO","msg":"End consume message.","message_count":2,"time":"0s"}
+`
+
 	MultiMessagesConsumerInterceptor(logger)(
 		subee.MultiMessagesConsumerFunc(func(ctx context.Context, msgs []subee.Message) error {
 			logger.Info("called single message consumer func")
@@ -86,12 +92,7 @@ func TestMultiMessagesConsumerInterceptor(t *testing.T) {
 		},
 	)
 
-	want := `{"level":"INFO","msg":"Start consume message.","message_count":2}
-{"level":"INFO","msg":"called single message consumer func"}
-{"level":"INFO","msg":"End consume message.","message_count":2,"time":"0s"}
-`
-	if got, want := buf.String(), want; got != want {
+	if got := buf.String(); got != want {
 		t.Errorf("\nwant:\n%sgot:\n%s", want, got)
 	}
-
 }

--- a/middlewares/logging/zap/zap_interceptor_test.go
+++ b/middlewares/logging/zap/zap_interceptor_test.go
@@ -1,0 +1,97 @@
+package subee_zap
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wantedly/subee"
+	message_testing "github.com/wantedly/subee/testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func dummyLogger(buf *bytes.Buffer) *zap.Logger {
+	encoder := zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+		LevelKey:       "level",
+		MessageKey:     "msg",
+		EncodeLevel:    zapcore.CapitalLevelEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+	})
+	core := zapcore.NewCore(encoder, zapcore.AddSync(buf), zapcore.InfoLevel)
+	return zap.New(core)
+}
+
+func dummySince() func(t time.Time) time.Duration {
+	return func(t time.Time) time.Duration {
+		return 0
+	}
+}
+
+func TestSingleMessageConsumerInterceptor(t *testing.T) {
+	since = dummySince()
+
+	defer func() {
+		since = func(t time.Time) time.Duration {
+			return time.Since(t)
+		}
+	}()
+
+	buf := &bytes.Buffer{}
+	logger := dummyLogger(buf)
+
+	SingleMessageConsumerInterceptor(logger)(
+		subee.SingleMessageConsumerFunc(func(ctx context.Context, msg subee.Message) error {
+			logger.Info("called single message consumer func")
+			return nil
+		}),
+	).Consume(
+		context.Background(),
+		message_testing.NewFakeMessage(nil, false, false),
+	)
+
+	want := `{"level":"INFO","msg":"Start consume message.","message_count":1}
+{"level":"INFO","msg":"called single message consumer func"}
+{"level":"INFO","msg":"End consume message.","message_count":1,"time":"0s"}
+`
+	if got, want := buf.String(), want; got != want {
+		t.Errorf("\nwant:\n%sgot:\n%s", want, got)
+	}
+}
+
+func TestMultiMessagesConsumerInterceptor(t *testing.T) {
+	since = dummySince()
+
+	defer func() {
+		since = func(t time.Time) time.Duration {
+			return time.Since(t)
+		}
+	}()
+
+	buf := &bytes.Buffer{}
+	logger := dummyLogger(buf)
+
+	MultiMessagesConsumerInterceptor(logger)(
+		subee.MultiMessagesConsumerFunc(func(ctx context.Context, msgs []subee.Message) error {
+			logger.Info("called single message consumer func")
+			return nil
+		}),
+	).Consume(
+		context.Background(),
+		[]subee.Message{
+			message_testing.NewFakeMessage(nil, false, false),
+			message_testing.NewFakeMessage(nil, false, false),
+		},
+	)
+
+	want := `{"level":"INFO","msg":"Start consume message.","message_count":2}
+{"level":"INFO","msg":"called single message consumer func"}
+{"level":"INFO","msg":"End consume message.","message_count":2,"time":"0s"}
+`
+	if got, want := buf.String(), want; got != want {
+		t.Errorf("\nwant:\n%sgot:\n%s", want, got)
+	}
+
+}

--- a/middlewares/recovery/recovery_interceptor_test.go
+++ b/middlewares/recovery/recovery_interceptor_test.go
@@ -1,0 +1,56 @@
+package subee_recovery
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/wantedly/subee"
+	message_testing "github.com/wantedly/subee/testing"
+)
+
+func writeHandler(buf *bytes.Buffer, tag string) RecoveryHandlerFunc {
+	return func(ctx context.Context, p interface{}) {
+		buf.Write([]byte(tag))
+	}
+}
+
+func TestSingleMessageConsumerInterceptor(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	tag := "SingleMessageConsumer"
+
+	SingleMessageConsumerInterceptor(writeHandler(buf, tag))(
+		subee.SingleMessageConsumerFunc(func(ctx context.Context, msg subee.Message) error {
+			panic("occurs panic")
+			return nil
+		}),
+	).Consume(
+		context.Background(),
+		message_testing.NewFakeMessage(nil, false, false),
+	)
+
+	if got, want := buf.String(), tag; got != want {
+		t.Errorf("want:%v, but: %v", want, got)
+	}
+}
+
+func TestMultiMessagesConsumerInterceptor(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	tag := "MultiMessagesConsumer"
+
+	SingleMessageConsumerInterceptor(writeHandler(buf, tag))(
+		subee.SingleMessageConsumerFunc(func(ctx context.Context, msg subee.Message) error {
+			panic("occurs panic")
+			return nil
+		}),
+	).Consume(
+		context.Background(),
+		message_testing.NewFakeMessage(nil, false, false),
+	)
+
+	if got, want := buf.String(), tag; got != want {
+		t.Errorf("want:%v, but: %v", want, got)
+	}
+}

--- a/middlewares/recovery/recovery_interceptor_test.go
+++ b/middlewares/recovery/recovery_interceptor_test.go
@@ -3,15 +3,16 @@ package subee_recovery
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/wantedly/subee"
 	message_testing "github.com/wantedly/subee/testing"
 )
 
-func writeHandler(buf *bytes.Buffer, tag string) RecoveryHandlerFunc {
+func writeHandler(buf *bytes.Buffer) RecoveryHandlerFunc {
 	return func(ctx context.Context, p interface{}) {
-		buf.Write([]byte(tag))
+		buf.Write([]byte(fmt.Sprint(p)))
 	}
 }
 
@@ -20,9 +21,9 @@ func TestSingleMessageConsumerInterceptor(t *testing.T) {
 
 	tag := "SingleMessageConsumer"
 
-	SingleMessageConsumerInterceptor(writeHandler(buf, tag))(
+	SingleMessageConsumerInterceptor(writeHandler(buf))(
 		subee.SingleMessageConsumerFunc(func(ctx context.Context, msg subee.Message) error {
-			panic("occurs panic")
+			panic(tag)
 			return nil
 		}),
 	).Consume(
@@ -31,7 +32,7 @@ func TestSingleMessageConsumerInterceptor(t *testing.T) {
 	)
 
 	if got, want := buf.String(), tag; got != want {
-		t.Errorf("want:%v, but: %v", want, got)
+		t.Errorf("\nwant:\n%sgot:\n%s", want, got)
 	}
 }
 
@@ -40,9 +41,9 @@ func TestMultiMessagesConsumerInterceptor(t *testing.T) {
 
 	tag := "MultiMessagesConsumer"
 
-	SingleMessageConsumerInterceptor(writeHandler(buf, tag))(
+	SingleMessageConsumerInterceptor(writeHandler(buf))(
 		subee.SingleMessageConsumerFunc(func(ctx context.Context, msg subee.Message) error {
-			panic("occurs panic")
+			panic(tag)
 			return nil
 		}),
 	).Consume(
@@ -51,6 +52,6 @@ func TestMultiMessagesConsumerInterceptor(t *testing.T) {
 	)
 
 	if got, want := buf.String(), tag; got != want {
-		t.Errorf("want:%v, but: %v", want, got)
+		t.Errorf("\nwant:\n%sgot:\n%s", want, got)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -5,6 +5,15 @@ import "time"
 // Option configures Config.
 type Option func(*Config)
 
+// WithSingleMessageConsumerInterceptors returns an Option that sets the SingleMessageConsumerInterceptor implementations(s).
+// Interceptors are called in order of addition.
+// e.g) interceptor1, interceptor2, interceptor3 => interceptor1 => interceptor2 => interceptor3 => MultiMessageConsumer.Consume
+func WithSingleMessageConsumerInterceptors(interceptors ...SingleMessageConsumerInterceptor) Option {
+	return func(c *Config) {
+		c.SingleMessageConsumer = chainSingleMessageConsumerInterceptors(c.SingleMessageConsumer, interceptors...)
+	}
+}
+
 // WithMultiMessagesConsumerInterceptors returns an Option that sets the MultiMessageConsumerInterceptor implementations(s).
 // Interceptors are called in order of addition.
 // e.g) interceptor1, interceptor2, interceptor3 => interceptor1 => interceptor2 => interceptor3 => MultiMessageConsumer.Consume
@@ -12,6 +21,17 @@ func WithMultiMessagesConsumerInterceptors(interceptors ...MultiMessagesConsumer
 	return func(c *Config) {
 		c.MultiMessagesConsumer = chainMultiMessagesConsumerInterceptors(c.MultiMessagesConsumer, interceptors...)
 	}
+}
+
+func chainSingleMessageConsumerInterceptors(consumer SingleMessageConsumer, interceptors ...SingleMessageConsumerInterceptor) SingleMessageConsumer {
+	if len(interceptors) == 0 {
+		return consumer
+	}
+
+	for i := len(interceptors) - 1; i >= 0; i-- {
+		consumer = interceptors[i](consumer)
+	}
+	return consumer
 }
 
 func chainMultiMessagesConsumerInterceptors(consumer MultiMessagesConsumer, interceptors ...MultiMessagesConsumerInterceptor) MultiMessagesConsumer {

--- a/options.go
+++ b/options.go
@@ -7,16 +7,16 @@ type Option func(*Config)
 
 // WithSingleMessageConsumerInterceptors returns an Option that sets the SingleMessageConsumerInterceptor implementations(s).
 // Interceptors are called in order of addition.
-// e.g) interceptor1, interceptor2, interceptor3 => interceptor1 => interceptor2 => interceptor3 => MultiMessageConsumer.Consume
+// e.g) interceptor1, interceptor2, interceptor3 => interceptor1 => interceptor2 => interceptor3 => SingleMessageConsumer.Consume
 func WithSingleMessageConsumerInterceptors(interceptors ...SingleMessageConsumerInterceptor) Option {
 	return func(c *Config) {
 		c.SingleMessageConsumer = chainSingleMessageConsumerInterceptors(c.SingleMessageConsumer, interceptors...)
 	}
 }
 
-// WithMultiMessagesConsumerInterceptors returns an Option that sets the MultiMessageConsumerInterceptor implementations(s).
+// WithMultiMessagesConsumerInterceptors returns an Option that sets the MultiMessagesConsumerInterceptor implementations(s).
 // Interceptors are called in order of addition.
-// e.g) interceptor1, interceptor2, interceptor3 => interceptor1 => interceptor2 => interceptor3 => MultiMessageConsumer.Consume
+// e.g) interceptor1, interceptor2, interceptor3 => interceptor1 => interceptor2 => interceptor3 => MultiMessagesConsumer.Consume
 func WithMultiMessagesConsumerInterceptors(interceptors ...MultiMessagesConsumerInterceptor) Option {
 	return func(c *Config) {
 		c.MultiMessagesConsumer = chainMultiMessagesConsumerInterceptors(c.MultiMessagesConsumer, interceptors...)

--- a/options_test.go
+++ b/options_test.go
@@ -30,6 +30,58 @@ func tagMultiMessagesConsumer(tag string) MultiMessagesConsumer {
 	})
 }
 
+func tagSingleMessageConsumerInterceptor(tag string) SingleMessageConsumerInterceptor {
+	return func(consumer SingleMessageConsumer) SingleMessageConsumer {
+		return SingleMessageConsumerFunc(func(ctx context.Context, msg Message) error {
+			writeBuffer(ctx, tag)
+			return errors.WithStack(consumer.Consume(ctx, msg))
+		})
+	}
+}
+
+func tagSingleMessageConsumer(tag string) SingleMessageConsumer {
+	return SingleMessageConsumerFunc(func(ctx context.Context, msg Message) error {
+		writeBuffer(ctx, tag)
+		return nil
+	})
+}
+
+func TestChainSingleMessageConsumerInterceptors(t *testing.T) {
+	tests := []struct {
+		consumer     SingleMessageConsumer
+		interceptors []SingleMessageConsumerInterceptor
+		want         string
+	}{
+		{
+			consumer: tagSingleMessageConsumer("consumer-A\n"),
+			interceptors: []SingleMessageConsumerInterceptor{
+				tagSingleMessageConsumerInterceptor("intr-A\n"),
+				tagSingleMessageConsumerInterceptor("intr-B\n"),
+				tagSingleMessageConsumerInterceptor("intr-C\n"),
+			},
+			want: "intr-A\nintr-B\nintr-C\nconsumer-A\n",
+		},
+		{
+			consumer:     tagSingleMessageConsumer("consumer-A\n"),
+			interceptors: []SingleMessageConsumerInterceptor{},
+			want:         "consumer-A\n",
+		},
+	}
+
+	for _, test := range tests {
+		chain := chainSingleMessageConsumerInterceptors(test.consumer, test.interceptors...)
+
+		ctx := context.WithValue(context.Background(), chainContextTestKey{}, new(bytes.Buffer))
+		chain.Consume(ctx, nil)
+
+		got := ctx.Value(chainContextTestKey{}).(*bytes.Buffer).String()
+
+		if test.want != got {
+			t.Errorf("chainSingleMessageConsumerInterceptors output is wrong. want: %v, got: %v", test.want, got)
+		}
+	}
+}
+
 func TestChainMultiMessagesConsumerInterceptors(t *testing.T) {
 	tests := []struct {
 		consumer     MultiMessagesConsumer

--- a/queue.go
+++ b/queue.go
@@ -6,8 +6,7 @@ import (
 )
 
 type queuedMessage interface {
-	Ack()
-	Nack()
+	Acknowledger
 	Count() int
 	Context() context.Context
 	SetContext(ctx context.Context)

--- a/queue.go
+++ b/queue.go
@@ -13,6 +13,24 @@ type queuedMessage interface {
 	GetEnqueuedAt() time.Time
 }
 
+type singleMessage struct {
+	Ctx        context.Context
+	Msg        Message
+	EnqueuedAt time.Time
+}
+
+func (s *singleMessage) Ack() { s.Msg.Ack() }
+
+func (s *singleMessage) Nack() { s.Msg.Nack() }
+
+func (s *singleMessage) Context() context.Context { return s.Ctx }
+
+func (s *singleMessage) SetContext(ctx context.Context) { s.Ctx = ctx }
+
+func (s *singleMessage) Count() int { return 1 }
+
+func (s *singleMessage) GetEnqueuedAt() time.Time { return s.EnqueuedAt }
+
 type multiMessages struct {
 	Ctx        context.Context
 	Msgs       []Message
@@ -38,24 +56,6 @@ func (m *multiMessages) Context() context.Context { return m.Ctx }
 func (m *multiMessages) SetContext(ctx context.Context) { m.Ctx = ctx }
 
 func (m *multiMessages) GetEnqueuedAt() time.Time { return m.EnqueuedAt }
-
-type singleMessage struct {
-	Ctx        context.Context
-	Msg        Message
-	EnqueuedAt time.Time
-}
-
-func (s *singleMessage) Ack() { s.Msg.Ack() }
-
-func (s *singleMessage) Nack() { s.Msg.Nack() }
-
-func (s *singleMessage) Context() context.Context { return s.Ctx }
-
-func (s *singleMessage) SetContext(ctx context.Context) { s.Ctx = ctx }
-
-func (s *singleMessage) Count() int { return 1 }
-
-func (s *singleMessage) GetEnqueuedAt() time.Time { return s.EnqueuedAt }
 
 func createQueue(
 	createCtx func() context.Context,

--- a/queue.go
+++ b/queue.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+type queuedMessage interface {
+	Count() int
+	Context() context.Context
+	GetEnqueuedAt() time.Time
+}
+
 type multiMessages struct {
 	Ctx        context.Context
 	Msgs       []Message
@@ -22,6 +28,28 @@ func (m *multiMessages) Nack() {
 		msg.Nack()
 	}
 }
+
+func (m *multiMessages) Count() int { return len(m.Msgs) }
+
+func (m *multiMessages) Context() context.Context { return m.Ctx }
+
+func (m *multiMessages) GetEnqueuedAt() time.Time { return m.EnqueuedAt }
+
+type singleMessage struct {
+	Ctx        context.Context
+	Msg        Message
+	EnqueuedAt time.Time
+}
+
+func (s *singleMessage) Ack() { s.Msg.Ack() }
+
+func (s *singleMessage) Nack() { s.Msg.Nack() }
+
+func (s *singleMessage) Context() context.Context { return s.Ctx }
+
+func (s *singleMessage) Count() int { return 1 }
+
+func (s *singleMessage) GetEnqueuedAt() time.Time { return s.EnqueuedAt }
 
 func createBufferedQueue(
 	createCtx func() context.Context,

--- a/queue.go
+++ b/queue.go
@@ -50,7 +50,8 @@ func (s *singleMessage) Ack() { s.Msg.Ack() }
 
 func (s *singleMessage) Nack() { s.Msg.Nack() }
 
-func (s *singleMessage) Context() context.Context       { return s.Ctx }
+func (s *singleMessage) Context() context.Context { return s.Ctx }
+
 func (s *singleMessage) SetContext(ctx context.Context) { s.Ctx = ctx }
 
 func (s *singleMessage) Count() int { return 1 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -69,7 +69,7 @@ func TestCreateBufferedQueue(t *testing.T) {
 		}
 
 		if m, ok := out.(*multiMessages); !ok {
-			t.Errorf("Item[%d] is %T type, want *subee.MultiMessagesConsumer type", i, m)
+			t.Errorf("Item[%d] is %T type, want *subee.multiMessages type", i, m)
 		}
 	}
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -67,6 +67,10 @@ func TestCreateBufferedQueue(t *testing.T) {
 		if got, want := out.Count(), n; got != want {
 			t.Errorf("Item[%d] has %d messages, want %d", i, got, want)
 		}
+
+		if m, ok := out.(*multiMessages); !ok {
+			t.Errorf("Item[%d] is %T type, want *subee.MultiMessagesConsumer type", i, m)
+		}
 	}
 
 	_, ok := <-outCh

--- a/queue_test.go
+++ b/queue_test.go
@@ -6,15 +6,11 @@ import (
 	"time"
 )
 
-func TestCreateBufferedQueue(t *testing.T) {
-	type fakeMessage struct{ Message }
+type fakeMessage struct {
+	Message
+}
 
-	inCh, outCh := createBufferedQueue(
-		context.Background,
-		3,
-		4*time.Millisecond,
-	)
-
+func queuing(inCh chan<- Message) {
 	go func() {
 		inCh <- &fakeMessage{}
 		inCh <- &fakeMessage{}
@@ -28,6 +24,42 @@ func TestCreateBufferedQueue(t *testing.T) {
 		inCh <- &fakeMessage{}
 		close(inCh)
 	}()
+}
+
+func TestQueue(t *testing.T) {
+	inCh, outCh := createQueue(
+		context.Background,
+	)
+
+	queuing(inCh)
+
+	for i, n := range []int{1, 1, 1, 1, 1, 1, 1, 1} {
+		out := <-outCh
+
+		if got, want := out.Count(), n; got != want {
+			t.Errorf("Item[%d] has %d messages, want %d", i, got, want)
+		}
+
+		if m, ok := out.(*singleMessage); !ok {
+			t.Errorf("Item[%d] is %T type, want *subee.singleMessage type", i, m)
+		}
+	}
+
+	_, ok := <-outCh
+
+	if ok {
+		t.Error("out channel should close")
+	}
+}
+
+func TestCreateBufferedQueue(t *testing.T) {
+	inCh, outCh := createBufferedQueue(
+		context.Background,
+		3,
+		4*time.Millisecond,
+	)
+
+	queuing(inCh)
 
 	for i, n := range []int{2, 3, 1, 2} {
 		out := <-outCh

--- a/queue_test.go
+++ b/queue_test.go
@@ -32,7 +32,7 @@ func TestCreateBufferedQueue(t *testing.T) {
 	for i, n := range []int{2, 3, 1, 2} {
 		out := <-outCh
 
-		if got, want := len(out.Msgs), n; got != want {
+		if got, want := out.Count(), n; got != want {
 			t.Errorf("Item[%d] has %d messages, want %d", i, got, want)
 		}
 	}


### PR DESCRIPTION
# WHY

Ideal functions of `subee` are "event propagation" and "asynchronous API for large scale workload".
Currently there is only "asynchronous API for large workload", so I would like to add the "event propagation" function.

Organizing terms

-  "Asynchronous API for Large Scale Workloads": Processing large amounts of messages at once
    - MultiMessagesConsumer
- "Event propagation": Process messages reliably one by one
    - SingleMessageConsumer.

# WHAT

Prepare a Constructor for 'SingleMessageConsumer' and 'MultiMessagesConsumer' so that they can be switched

@izumin5210 
