### PR TITLE
Consuming messages in parallel

### DIFF
--- a/context_helper.go
+++ b/context_helper.go
@@ -2,9 +2,13 @@ package subee
 
 import (
 	"context"
+	"time"
 )
 
-type loggerContextKey struct{}
+type (
+	loggerContextKey     struct{}
+	enqueuedAtContextKey struct{}
+)
 
 // GetLogger return Logger implementation set in the context.
 func GetLogger(ctx context.Context) Logger {
@@ -13,4 +17,12 @@ func GetLogger(ctx context.Context) Logger {
 
 func setLogger(ctx context.Context, l Logger) context.Context {
 	return context.WithValue(ctx, loggerContextKey{}, l)
+}
+
+func getEnqueuedAt(ctx context.Context) time.Time {
+	return ctx.Value(enqueuedAtContextKey{}).(time.Time)
+}
+
+func setEnqueuedAt(ctx context.Context, t time.Time) context.Context {
+	return context.WithValue(ctx, enqueuedAtContextKey{}, t)
 }

--- a/context_helper.go
+++ b/context_helper.go
@@ -14,12 +14,3 @@ func GetLogger(ctx context.Context) Logger {
 func setLogger(ctx context.Context, l Logger) context.Context {
 	return context.WithValue(ctx, loggerContextKey{}, l)
 }
-
-func queuingContext(sh StatsHandler) func() context.Context {
-	return func() context.Context {
-		ctx := context.Background()
-		ctx = sh.TagProcess(ctx, &BeginTag{})
-		ctx = sh.TagProcess(ctx, &EnqueueTag{})
-		return ctx
-	}
-}

--- a/engine.go
+++ b/engine.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
-	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -59,14 +57,7 @@ func (e *Engine) Start(ctx context.Context) error {
 
 	eg.Go(func() error {
 		defer close(sigDoneCh)
-		switch {
-		case e.Consumer != nil:
-			return errors.WithStack(e.startConsumingProcess(ctx))
-		case e.BatchConsumer != nil:
-			return errors.WithStack(e.startBatchConsumingProcess(ctx))
-		default:
-			panic("unreachable")
-		}
+		return errors.WithStack(newProcess(e).Start(ctx))
 	})
 
 	err := eg.Wait()
@@ -94,112 +85,4 @@ func (e *Engine) watchShutdownSignal(sigstopCh <-chan struct{}, cancel context.C
 			cancel()
 		}
 	}
-}
-
-func (e *Engine) startConsumingProcess(ctx context.Context) error {
-	consumer := chainConsumerInterceptors(e.Consumer, e.ConsumerInterceptors...)
-
-	err := e.startSubscribing(ctx, func(in Message) {
-		msg := &singleMessage{
-			Ctx:        e.createConsumingContext(),
-			Msg:        in,
-			EnqueuedAt: time.Now(),
-		}
-		e.handleMessage(msg, func(in queuedMessage) error {
-			m := in.(*singleMessage)
-			return errors.WithStack(consumer.Consume(m.Ctx, m.Msg))
-		})
-	})
-	return errors.WithStack(err)
-}
-
-func (e *Engine) startBatchConsumingProcess(ctx context.Context) error {
-	var (
-		err error
-		wg  sync.WaitGroup
-	)
-
-	inCh, outCh := createBufferedQueue(
-		e.createConsumingContext,
-		e.ChunkSize,
-		e.FlushInterval,
-	)
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		defer close(inCh)
-
-		err = errors.WithStack(e.startSubscribing(ctx, func(msg Message) { inCh <- msg }))
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		batchConsumer := chainBatchConsumerInterceptors(e.BatchConsumer, e.BatchConsumerInterceptors...)
-
-		e.Logger.Print("Start consuming process")
-		defer e.Logger.Print("Finish consuming process")
-
-		for m := range outCh {
-			e.handleMessage(m, func(in queuedMessage) error {
-				m := in.(*multiMessages)
-				return errors.WithStack(batchConsumer.BatchConsume(m.Ctx, m.Msgs))
-			})
-		}
-	}()
-
-	wg.Wait()
-
-	return err
-}
-
-func (e *Engine) startSubscribing(ctx context.Context, f func(msg Message)) error {
-	e.Logger.Print("Start subscribing process")
-	defer e.Logger.Print("Finish subscribing process")
-	return errors.WithStack(e.subscriber.Subscribe(ctx, f))
-}
-
-func (e *Engine) createConsumingContext() context.Context {
-	ctx := context.Background()
-	ctx = e.StatsHandler.TagProcess(ctx, &BeginTag{})
-	ctx = e.StatsHandler.TagProcess(ctx, &EnqueueTag{})
-	return ctx
-}
-
-func (e *Engine) handleMessage(m queuedMessage, handle func(queuedMessage) error) {
-	if e.AckImmediately {
-		m.Ack()
-	}
-
-	e.StatsHandler.HandleProcess(m.Context(), &Dequeue{
-		BeginTime: m.GetEnqueuedAt(),
-		EndTime:   time.Now(),
-	})
-
-	beginTime := time.Now()
-
-	m.SetContext(e.StatsHandler.TagProcess(m.Context(), &ConsumeBeginTag{}))
-
-	err := handle(m)
-
-	if !e.AckImmediately {
-		if err != nil {
-			m.Nack()
-		} else {
-			m.Ack()
-		}
-	}
-
-	e.StatsHandler.HandleProcess(m.Context(), &ConsumeEnd{
-		BeginTime: beginTime,
-		EndTime:   time.Now(),
-		Error:     err,
-	})
-
-	e.StatsHandler.HandleProcess(m.Context(), &End{
-		MsgCount:  m.Count(),
-		BeginTime: m.GetEnqueuedAt(),
-		EndTime:   time.Now(),
-	})
 }

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
+github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57 h1:eqyIo2HjKhKe/mJzTG8n4VqvLXIOEG+SLdDqX7xGtkY=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
@@ -102,6 +103,7 @@ go.uber.org/zap v1.9.1 h1:XCJQEf3W6eZaVwhRBof6ImoYGJSITeKWsyeh3HFu/5o=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d/go.mod h1:OWs+y06UdEOHN4y+MfF/py+xQ/tYqIWW03b70/CG9Rw=
+golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PCuwl28DDIc3VNnvY29DlIA=
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/process.go
+++ b/process.go
@@ -64,7 +64,9 @@ func (p *processImpl) startBatchConsumingProcess(ctx context.Context) error {
 
 	defer close(inCh)
 
+	p.wg.Add(1)
 	go func() {
+		defer p.wg.Done()
 		batchConsumer := chainBatchConsumerInterceptors(p.BatchConsumer, p.BatchConsumerInterceptors...)
 
 		p.Logger.Print("Start batch consuming process")

--- a/process.go
+++ b/process.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// process encapsulates a subscribing routine and a consuming messages routine.
 type process interface {
 	Start(ctx context.Context) error
 }
@@ -26,7 +27,7 @@ func newProcess(e *Engine) process {
 func (p *processImpl) Start(ctx context.Context) error {
 	p.Logger.Print("Start process")
 	defer p.Logger.Print("Finish process")
-	defer p.wg.Wait()
+	defer p.wg.Wait() // To wait for consuming all received messages.
 
 	switch {
 	case p.Consumer != nil:

--- a/process.go
+++ b/process.go
@@ -24,9 +24,9 @@ func newProcess(e *Engine) process {
 }
 
 func (p *processImpl) Start(ctx context.Context) error {
-	defer p.wg.Wait()
 	p.Logger.Print("Start process")
 	defer p.Logger.Print("Finish process")
+	defer p.wg.Wait()
 
 	switch {
 	case p.Consumer != nil:

--- a/queue.go
+++ b/queue.go
@@ -57,30 +57,6 @@ func (m *multiMessages) SetContext(ctx context.Context) { m.Ctx = ctx }
 
 func (m *multiMessages) GetEnqueuedAt() time.Time { return m.EnqueuedAt }
 
-func createQueue(
-	createCtx func() context.Context,
-) (
-	chan<- Message,
-	<-chan queuedMessage,
-) {
-	inCh := make(chan Message)
-	outCh := make(chan queuedMessage)
-
-	go func() {
-		defer close(outCh)
-
-		for msg := range inCh {
-			outCh <- &singleMessage{
-				Ctx:        createCtx(),
-				Msg:        msg,
-				EnqueuedAt: time.Now(),
-			}
-		}
-	}()
-
-	return inCh, outCh
-}
-
 func createBufferedQueue(
 	createCtx func() context.Context,
 	chunkSize int,

--- a/queue_test.go
+++ b/queue_test.go
@@ -41,10 +41,6 @@ func TestCreateBufferedQueue(t *testing.T) {
 		if got, want := out.Count(), n; got != want {
 			t.Errorf("Item[%d] has %d messages, want %d", i, got, want)
 		}
-
-		if m, ok := out.(*multiMessages); !ok {
-			t.Errorf("Item[%d] is %T type, want *subee.multiMessages type", i, m)
-		}
 	}
 
 	_, ok := <-outCh

--- a/queue_test.go
+++ b/queue_test.go
@@ -26,32 +26,6 @@ func queuing(inCh chan<- Message) {
 	}()
 }
 
-func TestQueue(t *testing.T) {
-	inCh, outCh := createQueue(
-		context.Background,
-	)
-
-	queuing(inCh)
-
-	for i, n := range []int{1, 1, 1, 1, 1, 1, 1, 1} {
-		out := <-outCh
-
-		if got, want := out.Count(), n; got != want {
-			t.Errorf("Item[%d] has %d messages, want %d", i, got, want)
-		}
-
-		if m, ok := out.(*singleMessage); !ok {
-			t.Errorf("Item[%d] is %T type, want *subee.singleMessage type", i, m)
-		}
-	}
-
-	_, ok := <-outCh
-
-	if ok {
-		t.Error("out channel should close")
-	}
-}
-
 func TestCreateBufferedQueue(t *testing.T) {
 	inCh, outCh := createBufferedQueue(
 		context.Background,

--- a/subscribers/cloudpubsub/subscriber.go
+++ b/subscribers/cloudpubsub/subscriber.go
@@ -16,9 +16,7 @@ type subscriberImpl struct {
 
 // CreateSubscriber returns Subscriber implementation.
 func CreateSubscriber(ctx context.Context, projectID, subscriptionID string, opts ...Option) (subee.Subscriber, error) {
-	cfg := &Config{
-		ReceiveSettings: pubsub.ReceiveSettings{Synchronous: true},
-	}
+	cfg := new(Config)
 	cfg.apply(opts)
 
 	sub := &subscriberImpl{


### PR DESCRIPTION
## WHY

To improve performance... 🚀 

## WHAT

- Simplify message consuming flow
    - remove redundant `chan` for a single message consumer
- Delegate responsibility of flow control of messages to subscribers
- Make execute `Consume` or `BatchConsume` in a new goroutine