### PR TITLE
Fix subscriber options

### DIFF
--- a/subscribers/cloudpubsub/option.go
+++ b/subscribers/cloudpubsub/option.go
@@ -5,6 +5,7 @@ import (
 	"google.golang.org/api/option"
 )
 
+// Config represents subscriber configuration.
 type Config struct {
 	ClientOpts      []option.ClientOption
 	ReceiveSettings pubsub.ReceiveSettings

--- a/subscribers/cloudpubsub/option.go
+++ b/subscribers/cloudpubsub/option.go
@@ -22,7 +22,7 @@ type Option func(*Config)
 // WithClientOptions returns an Option that set option.ClientOption implementation(s).
 func WithClientOptions(opts ...option.ClientOption) Option {
 	return func(c *Config) {
-		c.ClientOpts = opts
+		c.ClientOpts = append(c.ClientOpts, opts...)
 	}
 }
 


### PR DESCRIPTION
# WHY
Since `Options`, it may be better to use `append` internally.


# WHAT

[x] Use `append` 

@izumin5210 