### PR TITLE
Add obj not found error handling

### DIFF
--- a/cmd/subee/internal/generator/subscriber.go
+++ b/cmd/subee/internal/generator/subscriber.go
@@ -62,6 +62,9 @@ func (g *subscriberGeneratorImpl) Generate(ctx context.Context, params *Subscrib
 			}
 			break
 		}
+		if obj == nil {
+			return errors.Errorf("Message type %q not found in the given package path %q", params.Message, params.Package.Path)
+		}
 		params.Package.Path = obj.Pkg().Path()
 		params.Package.Name = obj.Pkg().Name()
 		if filepath.Base(params.Package.Path) == params.Package.Name {


### PR DESCRIPTION
## WHY

In [Need a subee cli installation guide · Issue #27 · wantedly/subee](https://github.com/wantedly/subee/issues/27), I found out the cli can panic easily when an unexpected package or a message type given.

## WHAT

Added a error handling branch.
Hi @izumin5210, I don't the error message is ok for this line, but I believe this check must be here.
Would you review this and/or give me some suggestion?