### PR TITLE
Stop watching signals, delegate it to `appctx.Global()`

### DIFF
--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-simple-batch-GOPATH--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-simple-batch-GOPATH--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-simple-batch-Modules--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-simple-batch-Modules--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-simple-single-GOPATH--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-simple-single-GOPATH--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-simple-single-Modules--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-simple-single-Modules--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Encoding_protobuf-batch-GOPATH--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Encoding_protobuf-batch-GOPATH--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Encoding_protobuf-batch-Modules--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Encoding_protobuf-batch-Modules--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Encoding_protobuf-single-GOPATH--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Encoding_protobuf-single-GOPATH--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Encoding_protobuf-single-Modules--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Encoding_protobuf-single-Modules--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type-batch-GOPATH--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type-batch-GOPATH--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type-batch-Modules--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type-batch-Modules--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type-single-GOPATH--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type-single-GOPATH--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type-single-Modules--cmd-book-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type-single-Modules--cmd-book-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type_and_alias-batch-GOPATH--cmd-author-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type_and_alias-batch-GOPATH--cmd-author-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type_and_alias-batch-Modules--cmd-author-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type_and_alias-batch-Modules--cmd-author-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type_and_alias-single-GOPATH--cmd-author-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type_and_alias-single-GOPATH--cmd-author-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type_and_alias-single-Modules--cmd-author-subscriber-run.go
+++ b/cmd/subee/internal/generator/.snapshots/TestSubscriberGenerator-with_Message_type_and_alias-single-Modules--cmd-author-subscriber-run.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/srvc/appctx"
 	"github.com/wantedly/subee"
 )
 
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/cmd/subee/internal/generator/subscriber.go
+++ b/cmd/subee/internal/generator/subscriber.go
@@ -181,8 +181,13 @@ func main() {
 	runTmpl = mustCreateTemplate("cmd/{{.Name}}/run.go",
 		`package main
 
+import (
+	"github.com/srvc/appctx"
+	"github.com/pkg/errors"
+)
+
 func run() error {
-	ctx := context.Background()
+	ctx := appctx.Global() // application-scope context
 
 	subscriber, err := createSubscriber(ctx)
 	if err != nil {

--- a/engine.go
+++ b/engine.go
@@ -2,12 +2,8 @@ package subee
 
 import (
 	"context"
-	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
 )
 
 // Engine is the framework instance.
@@ -45,44 +41,7 @@ func (e *Engine) Start(ctx context.Context) error {
 	e.Logger.Print("Start Pub/Sub worker")
 	defer e.Logger.Print("Finish Pub/Sub worker")
 
-	eg, ctx := errgroup.WithContext(ctx)
-	ctx, cancel := context.WithCancel(ctx)
 	ctx = setLogger(ctx, e.Logger)
 
-	sigDoneCh := make(chan struct{}, 1)
-
-	eg.Go(func() error {
-		return e.watchShutdownSignal(sigDoneCh, cancel)
-	})
-
-	eg.Go(func() error {
-		defer close(sigDoneCh)
-		return errors.WithStack(newProcess(e).Start(ctx))
-	})
-
-	err := eg.Wait()
-
-	return errors.WithStack(err)
-}
-
-func (e *Engine) watchShutdownSignal(sigstopCh <-chan struct{}, cancel context.CancelFunc) error {
-	sigCh := make(chan os.Signal, 1)
-
-	defer func() {
-		signal.Stop(sigCh)
-		close(sigCh)
-	}()
-
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-
-	for {
-		select {
-		case <-sigstopCh:
-			e.Logger.Print("Finish os signal monitoring")
-			return nil
-		case sig := <-sigCh:
-			e.Logger.Printf("Received signal: %v", sig)
-			cancel()
-		}
-	}
+	return errors.WithStack(newProcess(e).Start(ctx))
 }


### PR DESCRIPTION
⚠️ **THIS PR WILL INTRODUCE BREAKING CHANGES**

## WHY

when we want to use `subee` as a library, implicit signal handling is unnecessary.

## WHAT
stop watching signals on `subee.Engine`, and delete it to `appctx.Global()`