### PR TITLE
Support newrelic v3

### DIFF
--- a/stats/newrelic/go.mod
+++ b/stats/newrelic/go.mod
@@ -3,6 +3,6 @@ module github.com/wantedly/subee/stats/newrelic
 go 1.13
 
 require (
-	github.com/newrelic/go-agent v2.14.1+incompatible
+	github.com/newrelic/go-agent/v3 v3.2.0
 	github.com/wantedly/subee v0.5.0
 )

--- a/stats/newrelic/go.sum
+++ b/stats/newrelic/go.sum
@@ -1,5 +1,5 @@
-github.com/newrelic/go-agent v2.14.1+incompatible h1:rh+3g1mhz8WH3VD/ORq3QhQz4iqaClBlQ6q9KInojyE=
-github.com/newrelic/go-agent v2.14.1+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
+github.com/newrelic/go-agent/v3 v3.2.0 h1:VyVCJYgqNCMSa5b92dcREL7fxNIobTw6DVolTWJDJJs=
+github.com/newrelic/go-agent/v3 v3.2.0/go.mod h1:H28zDNUC0U/b7kLoY4EFOhuth10Xu/9dchozUiOseQQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/wantedly/subee v0.5.0 h1:MXGlZYHNVxyxsolIcpwymdZHMR9OL8WlggCwu8//I0M=

--- a/stats/newrelic/newrelic.go
+++ b/stats/newrelic/newrelic.go
@@ -3,13 +3,13 @@ package nrsubee
 import (
 	"context"
 
-	newrelic "github.com/newrelic/go-agent"
+	"github.com/newrelic/go-agent/v3/newrelic"
 
 	"github.com/wantedly/subee"
 )
 
 // NewStatsHandler creates a new subee.StatsHandler instance for measuring application performances with New Relic.
-func NewStatsHandler(app newrelic.Application, opts ...Option) subee.StatsHandler {
+func NewStatsHandler(app *newrelic.Application, opts ...Option) subee.StatsHandler {
 	cfg := DefaultConfig()
 	cfg.apply(opts)
 	return &statsHandler{
@@ -19,7 +19,7 @@ func NewStatsHandler(app newrelic.Application, opts ...Option) subee.StatsHandle
 }
 
 type statsHandler struct {
-	app newrelic.Application
+	app *newrelic.Application
 	cfg *Config
 }
 
@@ -31,7 +31,7 @@ type (
 func (sh *statsHandler) TagProcess(ctx context.Context, t subee.Tag) context.Context {
 	switch t.(type) {
 	case *subee.EnqueueTag:
-		txn := sh.app.StartTransaction(sh.cfg.TransactionName, nil, nil)
+		txn := sh.app.StartTransaction(sh.cfg.TransactionName)
 		ctx := newrelic.NewContext(ctx, txn)
 		seg := newrelic.StartSegment(txn, sh.cfg.QueueingSegmentName)
 		return context.WithValue(ctx, queueContextKey{}, seg)


### PR DESCRIPTION
Version 3 of the newrelic agent has been released.

This patch migrates `github.com/wantedly/subee/stats/newrelic` to use the new agent according to the migration guide here :point_right: https://github.com/newrelic/go-agent/blob/v3.0.0/MIGRATION.md

As the public dependency is bumped, it should be released as `stats/newrelic/v0.2.0`.